### PR TITLE
Don't swallow errors while validating, show the error message from Let's Encrypt

### DIFF
--- a/src/LEOrder.php
+++ b/src/LEOrder.php
@@ -508,7 +508,15 @@ class LEOrder
             $this->sleep->for(1);
             $auth->updateData();
         }
-        $this->log->notice("DNS challenge for $identifier validated");
+
+        $this->log->notice("DNS challenge for $identifier: " . $auth->status);
+
+        if ($auth->status != 'valid') {
+            $challenge = $auth->getChallenge(LEOrder::CHALLENGE_TYPE_DNS);
+            if (isset($challenge['error'])) {
+                $this->log->error($challenge['error']['detail'], ['auth' => $auth]);
+            }
+        }
 
         return true;
     }


### PR DESCRIPTION
When the DNS validation by Let's Encrypt fails, the error is never shown and the log says "validated".

Even if the local DNS check succeeds, that doesn't mean that the check by Let's Encrypt will always succeed.